### PR TITLE
Update and Refactor

### DIFF
--- a/packer/build/service.sls
+++ b/packer/build/service.sls
@@ -7,8 +7,7 @@
 
 Install Unzip:
   pkg.installed:
-  - names:
-    - unzip
+    - name: unzip
 
 Create Initial Packer Directory:
   file.directory:
@@ -16,31 +15,31 @@ Create Initial Packer Directory:
 
 Create Template Directory:
   file.directory:
-  - name: /srv/packer/templates
-  - require:
-    - file: /srv/packer
+    - name: /srv/packer/templates
+    - require:
+      - file: /srv/packer
 
 Create ISO Directory:
   file.directory:
-  - name: /srv/packer/iso
-  - require:
-    - file: /srv/packer
+    - name: /srv/packer/iso
+    - require:
+      - file: /srv/packer
 
 Create Packer build Scripts Director:
   file.directory:
-  - name: /srv/packer/build/scripts
-  - makedirs: true
-  - require:
-    - file: /srv/packer
+    - name: /srv/packer/build/scripts
+    - makedirs: true
+    - require:
+      - file: /srv/packer
 
 {% if pillar.virtualbox is defined %}
 
  Create Virtualbox Build Directory:
   file.directory:
-  - name : /srv/packer/build/virtualbox
-  - makedirs: true
-  - require:
-    - file: /srv/packer
+    - name : /srv/packer/build/virtualbox
+    - makedirs: true
+    - require:
+      - file: /srv/packer
 
 {% endif %}
 
@@ -48,10 +47,10 @@ Create Packer build Scripts Director:
 
 Create VMware Workstation Build Directory:
   file.directory:
-  - name: /srv/packer/build/vmware
-  - makedirs: true
-  - require:
-    - file: /srv/packer
+    - name: /srv/packer/build/vmware
+    - makedirs: true
+    - require:
+      - file: /srv/packer
 
 {% endif %}
 
@@ -61,26 +60,26 @@ Create Packer Binary folder:
 
 Download Packer Binary:
   cmd.run:
-  - name: wget {{ build.source_url }}/{{ source_file }}
-  - unless: test -e /root/{{ source_file }}
-  - cwd: /root
+    - name: wget {{ build.source_url }}/{{ source_file }}
+    - unless: test -e /root/{{ source_file }}
+    - cwd: /root
 
 Unzip Packer binary:
   cmd.run:
-  - name: unzip -o {{ source_file }} -d /usr/local/packer
-  - unless: test -e /usr/local/packer/packer
-  - require:
-    - pkg: Install Unzip
-    - file: /usr/local/packer
-    - cmd: Download Packer Binary
+    - name: unzip -o {{ source_file }} -d /usr/local/packer
+    - unless: test -e /usr/local/packer/packer
+    - require:
+      - pkg: Install Unzip
+      - file: /usr/local/packer
+      - cmd: Download Packer Binary
 
 {%- for binary in build.binaries %}
 
 /usr/bin/{{ binary }}:
   file.symlink:
-  - target: /usr/local/packer/{{ binary }}
-  - require:
-    - cmd: Unzip Packer binary
+    - target: /usr/local/packer/{{ binary }}
+    - require:
+      - cmd: Unzip Packer binary
 
 {%- endfor %}
 
@@ -88,7 +87,7 @@ Unzip Packer binary:
 
 packer_install_package:
   pkg.installed:
-  - name: packer_x64_en
+    - name: packer_x64_en
 
 {%- endif %}
 

--- a/packer/build/service.sls
+++ b/packer/build/service.sls
@@ -5,34 +5,39 @@
 
 {% if grains.kernel == "Linux" %}
 
-packer_packages:
+Install Unzip:
   pkg.installed:
   - names:
     - unzip
 
-/srv/packer:
-  file.directory
-
-/srv/packer/templates:
+Create Initial Packer Directory:
   file.directory:
+    - name: /srv/packer
+
+Create Template Directory:
+  file.directory:
+  - name: /srv/packer/templates
   - require:
     - file: /srv/packer
 
-/srv/packer/iso:
+Create ISO Directory:
   file.directory:
+  - name: /srv/packer/iso
   - require:
     - file: /srv/packer
 
-/srv/packer/build/scripts:
+Create Packer build Scripts Director:
   file.directory:
+  - name: /srv/packer/build/scripts
   - makedirs: true
   - require:
     - file: /srv/packer
 
 {% if pillar.virtualbox is defined %}
 
-/srv/packer/build/virtualbox:
+ Create Virtualbox Build Directory:
   file.directory:
+  - name : /srv/packer/build/virtualbox
   - makedirs: true
   - require:
     - file: /srv/packer
@@ -41,31 +46,33 @@ packer_packages:
 
 {% if pillar.vmware_workstation is defined %}
 
-/srv/packer/build/vmware:
+Create VMware Workstation Build Directory:
   file.directory:
+  - name: /srv/packer/build/vmware
   - makedirs: true
   - require:
     - file: /srv/packer
 
 {% endif %}
 
-/usr/local/packer:
-  file.directory
+Create Packer Binary folder:
+  file.directory:
+    - name: /usr/local/packer
 
-packer_download_package:
+Download Packer Binary:
   cmd.run:
   - name: wget {{ build.source_url }}/{{ source_file }}
   - unless: test -e /root/{{ source_file }}
   - cwd: /root
 
-packer_unzip_package:
+Unzip Packer binary:
   cmd.run:
   - name: unzip -o {{ source_file }} -d /usr/local/packer
   - unless: test -e /usr/local/packer/packer
   - require:
-    - pkg: packer_packages
+    - pkg: Install Unzip
     - file: /usr/local/packer
-    - cmd: packer_download_package
+    - cmd: Download Packer Binary
 
 {%- for binary in build.binaries %}
 
@@ -73,7 +80,7 @@ packer_unzip_package:
   file.symlink:
   - target: /usr/local/packer/{{ binary }}
   - require:
-    - cmd: packer_unzip_package
+    - cmd: Unzip Packer binary
 
 {%- endfor %}
 

--- a/packer/build/system.sls
+++ b/packer/build/system.sls
@@ -6,7 +6,7 @@ include:
 
 {%- for system_name, system in build.system.iteritems() %}
 
-packer_system_{{ system_name }}:
+Running Packer {{ system_name }} Build:
   git.latest:
   - name: {{ system.source.address }}
   - target: /srv/packer/templates/{{ system_name }}

--- a/packer/map.jinja
+++ b/packer/map.jinja
@@ -1,12 +1,12 @@
 {%- set build = salt['grains.filter_by']({
     'Debian': {
-        'version': '0.7.5',
-        'binaries': [ 'packer', 'packer-builder-digitalocean', 'packer-command-build', 'packer-post-processor-vagrant', 'packer-provisioner-puppet-masterless', 'packer-builder-amazon-chroot', 'packer-builder-openstack', 'packer-command-fix', 'packer-provisioner-ansible-local', 'packer-provisioner-salt-masterless', 'packer-builder-amazon-ebs', 'packer-builder-virtualbox', 'packer-command-inspect', 'packer-provisioner-chef-solo', 'packer-provisioner-shell', 'packer-builder-amazon-instance', 'packer-builder-vmware', 'packer-command-validate', 'packer-provisioner-file' ],
-        'source_url': 'https://dl.bintray.com/mitchellh/packer',
+        'version': '1.2.1',
+        'binaries': [],
+        'source_url': 'https://releases.hashicorp.com/packer/',
     },
     'RedHat': {
-        'version': '0.7.5',
-        'binaries': [ 'packer', 'packer-builder-digitalocean', 'packer-command-build', 'packer-post-processor-vagrant', 'packer-provisioner-puppet-masterless', 'packer-builder-amazon-chroot', 'packer-builder-openstack', 'packer-command-fix', 'packer-provisioner-ansible-local', 'packer-provisioner-salt-masterless', 'packer-builder-amazon-ebs', 'packer-builder-virtualbox', 'packer-command-inspect', 'packer-provisioner-chef-solo', 'packer-provisioner-shell', 'packer-builder-amazon-instance', 'packer-builder-vmware', 'packer-command-validate', 'packer-provisioner-file' ],
-        'source_url': 'https://dl.bintray.com/mitchellh/packer',
+        'version': '1.2.1',
+        'binaries': [],
+        'source_url': 'https://releases.hashicorp.com/packer/',
     },
 }, merge=salt['pillar.get']('packer:build')) %}


### PR DESCRIPTION
Moved directory naming directives to separate -name calls and used plain language naming for state IDs. Also updated the URL's and release to make current with the hashicorp release. New binaries are no longer required for many common items. It is possible to re-add the additional binary grab with the binaries dictionary in the map.jinja. 